### PR TITLE
Remove badge from Help sidebar item

### DIFF
--- a/backend/controllers/plugin.controller.js
+++ b/backend/controllers/plugin.controller.js
@@ -44,15 +44,15 @@ exports.sidebar = (req,res) => {
         icon: 'https://res.cloudinary.com/eyiajd/image/upload/v1630472654/sidebarplugin/all-files_ewrlii.svg',
         action: 'View All Files',
         badge:{
-          number: 10,
-          type: 'Info'
+          number: 50,
+          type: 'Primary'
         }
       },{
         title: 'Shared',
         icon: 'https://res.cloudinary.com/eyiajd/image/upload/v1630472833/sidebarplugin/users_ovn4oc.svg',
         action: 'View Shared Files',
         badge:{
-          number: 1,
+          number: 2,
           type: 'Info'
         }
       },{
@@ -68,17 +68,13 @@ exports.sidebar = (req,res) => {
         icon: 'https://res.cloudinary.com/eyiajd/image/upload/v1630472955/sidebarplugin/trash_ms7mit.svg',
         action: 'View Trash',
         badge:{
-          count: 2,
-          type: 'Info'
+          count: 6,
+          type: 'Warning'
         }
       },{
         title: 'Help',
         icon: 'https://res.cloudinary.com/eyiajd/image/upload/v1630472990/sidebarplugin/help-circle_zlzd4p.svg',
         action: 'View Help',
-        badge:{
-          number: 10,
-          type: 'Info'
-        }
       }]
   };
 


### PR DESCRIPTION
# Description

This change removes the badge from the Help sidebar item as it doesn't receive notifications. No new dependencies were required for this change.

> Fixes #183 

# How Has This Been Tested?

Visiting http://localhost:5500/sidebar when the server is running in development mode
Visiting http://companyfiles.zuri.chat/sidebar when the change goes live

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A)
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] My changes generate no lint warnings