### PR TITLE
fix: adding relevant fields to data returned from the '/info' route

### DIFF
--- a/backend/controllers/plugin.controller.js
+++ b/backend/controllers/plugin.controller.js
@@ -5,15 +5,16 @@ const pluginName = 'Company Files Management Plug-In';
 
 exports.info = async (req, res) => {
   const repoInfo = await axios.get('https://api.github.com/repos/zurichat/zc_plugin_company_files');
+  const baseUrl = `${req.protocol}://${req.get('host')}`;
 
   res.status(200).json({
     status: 'success',
     pluginId,
     pluginName,
-    pluginUrl: 'http://companyfiles.zuri.chat',
-    sidebarUrl: 'http://companyfiles.zuri.chat/sidebar',
-    infoUrl: 'http://companyfiles.zuri.chat/info',
-    pingUrl: 'http://companyfiles.zuri.chat/ping',
+    pluginUrl: `${baseUrl}`,
+    sidebarUrl: `${baseUrl}/sidebar`,
+    infoUrl: `${baseUrl}/info`,
+    pingUrl: `${baseUrl}/ping`,
     description: 'An effective file management system that improves business workflow, organizes important data and provides a searchable database for quick retrieval.',
     author,
     version,
@@ -36,7 +37,7 @@ exports.info = async (req, res) => {
   });
 }
 
-exports.sidebar = (req,res) => {
+exports.sidebar = (req, res) => {
   const sidebarListObject = {
       status: 'success',
       pluginId,
@@ -87,4 +88,8 @@ exports.sidebar = (req,res) => {
   };
 
   res.status(200).json(sidebarListObject);
+}
+
+exports.ping = (req, res) => {
+  res.status(200).json({ status: 'success', message: 'Server is up & running...' });
 }

--- a/backend/controllers/plugin.controller.js
+++ b/backend/controllers/plugin.controller.js
@@ -1,5 +1,5 @@
 const axios = require('axios');
-const { name, version, author, license, bugs: issues } = require('../../package.json');
+const { name, version, author, license, bugs } = require('../../package.json');
 const pluginId = name;
 const pluginName = 'Company Files Management Plug-In';
 
@@ -7,30 +7,38 @@ exports.info = async (req, res) => {
   const repoInfo = await axios.get('https://api.github.com/repos/zurichat/zc_plugin_company_files');
 
   res.status(200).json({
+    status: 'success',
     pluginId,
     pluginName,
+    pluginUrl: 'http://companyfiles.zuri.chat',
+    sidebarUrl: 'http://companyfiles.zuri.chat/sidebar',
+    infoUrl: 'http://companyfiles.zuri.chat/info',
+    pingUrl: 'http://companyfiles.zuri.chat/ping',
     description: 'An effective file management system that improves business workflow, organizes important data and provides a searchable database for quick retrieval.',
-    version,
     author,
+    version,
     repo: {
       type: 'git',
       url: repoInfo.data.html_url,
       gitUrl: repoInfo.data.git_url,
       license,
-      issues,
-      hasIssues: repoInfo.data.has_issues,
-      hasOpenIssues: repoInfo.data.open_issues > 0,
-      openIssuesCount: repoInfo.data.open_issues,
+      issues: {
+        ...bugs,
+        hasIssues: repoInfo.data.has_issues,
+        hasOpenIssues: repoInfo.data.open_issues > 0,
+        openIssuesCount: repoInfo.data.open_issues
+      },
       starsCount: repoInfo.data.stargazers_count,
       forksCount: repoInfo.data.forks,
       createdAt: repoInfo.data.created_at,
       lastUpdated: repoInfo.data.updated_at
-    },
+    }
   });
 }
 
 exports.sidebar = (req,res) => {
   const sidebarListObject = {
+      status: 'success',
       pluginId,
       pluginName,
       organisationId: '10f82718-672e-48c2-8fb2-ae26db5980e6',

--- a/backend/routes/plugin.router.js
+++ b/backend/routes/plugin.router.js
@@ -1,6 +1,7 @@
 const router = require('express').Router();
-const { info, sidebar } = require('../controllers/plugin.controller');
+const { ping, info, sidebar } = require('../controllers/plugin.controller');
 
+router.get('/ping', ping);
 router.get('/info', info);
 router.get('/sidebar', sidebar);
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "type": "git",
     "url": "git+https://github.com/zurichat/zc_plugin_company_files.git"
   },
-  "author": "Team Galileo devs",
+  "author": "Team Galileo devs ~ HNGi8",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/zurichat/zc_plugin_company_files/issues"


### PR DESCRIPTION
# Description

This change adds relevant fields to the JSON data returned by '/info' route. It also adds the '/ping' route.

> Fixes #182  (issue)

# How Has This Been Tested?

Visiting http://127.0.0.1:5500/info when the server is running in development mode & visiting http://companyfiles.zuri.chat/info when the change goes live.
Visiting http://127.0.0.1:5500/ping when the server is running in development mode & visiting http://companyfiles.zuri.chat/ping when the change goes live.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (_N/A_)
- [ ] I have made corresponding changes to the documentation (_N/A_)
- [x] My changes generate no lint warnings