### PR TITLE
fix:added route for the homepage and fixed the route for allfiles

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,6 +9,7 @@ import Help from "./components/Help/Help";
 import Shared from "./components/Shared/Shared";
 import Sidebar from "./components/SideBar/Sidebar";
 import Trash from "./components/Trash/Trash";
+import Home from "./components/Home/Home";
 
 function App() {
   return (
@@ -17,6 +18,9 @@ function App() {
         {/* <Sidebar /> */}
         <Switch>
           <Route exact path="/">
+            <Home />
+          </Route>
+          <Route exact path="/files">
             <AllFiles />
           </Route>
           <Route path="/shared">

--- a/frontend/src/components/All files/AllFiles.js
+++ b/frontend/src/components/All files/AllFiles.js
@@ -6,9 +6,7 @@ import RecentlyViewed from "../RecentlyViewed/RecentlyViewed";
 function AllFiles() {
     return (
         <div>
-            <RecentlyViewed/>
-            <Folder/>
-            <Files/>
+            All files will be rendered here in list/grid view
         </div>
     )
 }

--- a/frontend/src/components/Home/Home.js
+++ b/frontend/src/components/Home/Home.js
@@ -1,0 +1,15 @@
+import React from "react";
+import RecentlyViewed from "../RecentlyViewed/RecentlyViewed";
+import Folder from "../Folder/Folder";
+import Files from "../Files/Files";
+function Home() {
+	return (
+		<div>
+			<RecentlyViewed />
+			<Folder />
+			<Files />
+		</div>
+	);
+}
+
+export default Home;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4896,15 +4896,6 @@
 "fs.realpath@^1.0.0":
   "version" "1.0.0"
 
-"fsevents@^1.2.7":
-  "version" "1.2.13"
-  dependencies:
-    "bindings" "^1.5.0"
-    "nan" "^2.12.1"
-
-"fsevents@^2.1.2", "fsevents@^2.1.3", "fsevents@~2.3.2":
-  "version" "2.3.2"
-
 "function-bind@^1.1.1":
   "version" "1.1.1"
 


### PR DESCRIPTION
# Description

The route for the homepage("/") has been added and the route for "/allfiles" has been fixed such that the plugin renders the Recent, Folders and Files summaries cards on load

> Fixes #264 

# How Has This Been Tested?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no lint warnings