### PR TITLE
feat: check for duplicate files

### DIFF
--- a/backend/controllers/file.controller.js
+++ b/backend/controllers/file.controller.js
@@ -90,3 +90,27 @@ exports.getArchivedFiles = async (req, res) => {
     return error.response.data;
   }
 }
+
+// check for duplicate files with md5 values
+exports.isDuplicate = async (req, res) => {
+  try {
+    const { md5Hash } = req.body;
+    const { data } = await API.fetchAll();
+    let fileExists = false;
+    // loop through response object and check if md5Hash value exist
+    data.forEach(fileObject => {
+      if (fileObject.md5Hash === md5Hash) fileExists = true;
+    });
+    if (fileExists) {
+      return res
+        .status(200)
+        .json({ status: 200, message: "This is a duplicate file", duplicate: fileExists, });
+    } else {
+      return res
+        .status(200)
+        .json({ status: 200, message: "This is a new file", duplicate: fileExists, });
+    }
+  } catch (error) {
+    res.status(500).json(error);
+  }
+}

--- a/backend/routes/file.route.js
+++ b/backend/routes/file.route.js
@@ -8,6 +8,7 @@ const {
   getArchivedFiles,
   searchByDate,
   searchStarredFiles,
+  isDuplicate,
 } = require('../controllers/file.controller');
 
 // CREATE A NEW FILE
@@ -27,6 +28,9 @@ router.get('/searchByDate', searchByDate);
 
 // SEARCH STARRED FILES
 router.get('/searchStarredFiles', searchStarredFiles)
+
+// CHECK FOR DUPLICATES
+router.post('/is-duplicate', isDuplicate);
 
 router.route('/write/:id')
   .put(fileUpdate)

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-plugin-prettier": "^3.4.1",
         "husky": "^7.0.2",
         "lint-staged": "^11.1.2",
+        "md5-file": "^5.0.0",
         "morgan": "^1.10.0",
         "nodemon": "^2.0.12",
         "prettier": "^2.3.2"
@@ -3935,6 +3936,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/md5-file": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-5.0.0.tgz",
+      "integrity": "sha512-xbEFXCYVWrSx/gEKS1VPlg84h/4L20znVIulKw6kMfmBUAZNAnF00eczz9ICMl+/hjQGo5KSXRxbL/47X3rmMw==",
+      "dev": true,
+      "bin": {
+        "md5-file": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/media-typer": {
@@ -9399,6 +9412,12 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
       "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
+      "dev": true
+    },
+    "md5-file": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-5.0.0.tgz",
+      "integrity": "sha512-xbEFXCYVWrSx/gEKS1VPlg84h/4L20znVIulKw6kMfmBUAZNAnF00eczz9ICMl+/hjQGo5KSXRxbL/47X3rmMw==",
       "dev": true
     },
     "media-typer": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-prettier": "^3.4.1",
     "husky": "^7.0.2",
     "lint-staged": "^11.1.2",
+    "md5-file": "^5.0.0",
     "morgan": "^1.10.0",
     "nodemon": "^2.0.12",
     "prettier": "^2.3.2"


### PR DESCRIPTION
# Description

This feature helps to check files for duplicates by comparing new md5Hash value with the old ones
The endpoint ```/files/is-duplicate``` accepts a POST Request of the new md5Hash value in the JSON body

# Issue fixed.

> Fixes #7 

# Installed Dependency

```md5-file``` was installed with ```--save-dev``` flag and it was used to generate md5 values to check for md5 comparison and test

# How Has This Been Tested?

I started a local server on my machine on port 5500 to test the endpoint via `POSTMAN`


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no lint warnings